### PR TITLE
Allow spaces in work dir

### DIFF
--- a/src/utils/workDir.ts
+++ b/src/utils/workDir.ts
@@ -4,7 +4,7 @@ import { dirname, resolve } from 'path';
 export function getWorkDir(filepath) {
      try {
         const path = execSync("stack query", { cwd: dirname(filepath) }).toString();
-        const re = /.*path:\s([^\n\s]*)\s.*/
+        const re = /.*path:\s*(.*?)\s*?\n/
         var extract = re.exec(path)[1];
 
         // Windows


### PR DESCRIPTION
Changed regex to allow spaces in working directory path. Works for me.
Although [does not work](https://github.com/commercialhaskell/intero/issues/381) in intero yet  :)