### PR TITLE
Feature: Allow type inference of complete expressions

### DIFF
--- a/src/Providers/Type/index.ts
+++ b/src/Providers/Type/index.ts
@@ -6,13 +6,24 @@ import { normalizePath } from '../../utils/document';
 class TypeProvider implements vscode.HoverProvider {
     public provideHover(document: vscode.TextDocument, position: vscode.Position, token: vscode.CancellationToken): Thenable<vscode.Hover> {
         return new Promise((resolve, reject) => {
-            const wordInfo = getNearWord(position, document.getText());
+            // current editor
+            const editor = vscode.window.activeTextEditor;
             let filePath = normalizePath(document.uri.fsPath);
+            
+            // check if there is no selection
+            if (editor.selection.isEmpty || !editor.selection.contains(position)) {
+                const wordInfo = getNearWord(position, document.getText());
 
-            InteroSpawn.getInstance().requestType(filePath, position, wordInfo)
-            .then(hover => {
-                resolve(hover);  
-            });
+                InteroSpawn.getInstance().requestType(filePath, position, wordInfo)
+                .then(hover => {
+                    resolve(hover);  
+                });
+            } else {
+                InteroSpawn.getInstance().requestType(filePath, position, { word: "", start: editor.selection.start.character, end: editor.selection.end.character })
+                .then(hover => {
+                    resolve(hover);  
+                });
+            }
         })
     }
 }


### PR DESCRIPTION
Just select the expression in the text editor and hover over it.
Very simple solution for the start; for sure this could be improved; e.g. allow multi-line selections.

A picture is worth a thousand words:
![grafik](https://user-images.githubusercontent.com/969523/34193648-218b9aee-e555-11e7-9c55-f0a13839227d.png)
