### PR TITLE
[Discussion] [Live Share] Restricting language services to local files

### DIFF
--- a/src/extension.ts
+++ b/src/extension.ts
@@ -29,7 +29,10 @@ export function activate(context: vscode.ExtensionContext) {
     InteroSpawn.getInstance().tryNewIntero(documentPath)
     .catch(error => console.log(error));
 
-    const sel:vscode.DocumentSelector = 'haskell';
+    const sel:vscode.DocumentSelector = [
+        { language: 'haskell', scheme: 'file' },
+        { language: 'haskell', scheme: 'untitled' }
+    ];
 
     /* Type hover */
     context.subscriptions.push(vscode.languages.registerHoverProvider(sel, new TypeProvider()));


### PR DESCRIPTION
In preparation for [Visual Studio Live Share](https://aka.ms/vsls) adding support for "guests" to receive remote language services for Haskell, this PR simply updates the current `DocumentSelector` to be limited to `file` and `untitled` (unsaved) files. This way, when someone has this extension installed, and joins a Live Share session (where files use the `vsls:` scheme), their language services will be entirely derived from the remote/host side, which provides a more accurate and project-wide experience (guests in Live Share don't have local file access to the project they're collaborating with).

*Note: As an example, the TypeScript/JavaScript language services that come in-box with VS Code [already have this scheme restriction](https://github.com/Microsoft/vscode/blob/master/extensions/typescript-language-features/src/utils/fileSchemes.ts#L12), and so this PR replicates that behavior.*