### PR TITLE
Add a required space in the regex which extracts the current project …

### DIFF
--- a/src/utils/workDir.ts
+++ b/src/utils/workDir.ts
@@ -4,7 +4,7 @@ import { dirname, resolve } from 'path';
 export function getWorkDir(filepath) {
      try {
         const path = execSync("stack query", { cwd: dirname(filepath) }).toString();
-        const re = /.*path:\s*(.*?)\s*?\n/
+        const re = /.*\spath:\s*(.*?)\s*?\n/
         var extract = re.exec(path)[1];
 
         // Windows


### PR DESCRIPTION
…path from a `stack query` result to avoid matching accidental package versions instead. 

I am not sure if this is a fireproof solution for the future, but without changing the whole code to properly parse the query result instead of just regexing it, it seems to work fine.