### PR TITLE
Quick Check Fails on Windows

### DIFF
--- a/src/helpers/testCode.ts
+++ b/src/helpers/testCode.ts
@@ -144,7 +144,7 @@ export function testHaskellFile(filePath, stackWd) {
                     if (err) reject(err);
                     console.log('QuickCheking...');
                     
-                    shell(`stack runhaskell ${newPath}`, {}).then(std => {
+                    shell(`stack runhaskell "${newPath}"`, {}).then(std => {
                         console.log(std[0]);
                         fs.unlinkSync(newPath);
                         resolve(parseStdout(std[0]));


### PR DESCRIPTION
If the window file path contains a space then quick check will not run; this fixes that issue.  Checked on Windows 10