### PR TITLE
Removed references to stack-run

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,12 +54,9 @@
   * Install [Intero](https://github.com/commercialhaskell/intero) (code completion and type information), [QuickCheck](https://hackage.haskell.org/package/QuickCheck) (test suite) and [stack-run](https://hackage.haskell.org/package/stack-run):
 
     ```shell
-    stack install intero QuickCheck stack-run  # for a global installation
-    stack build intero QuickCheck stack-run # for a local installation
+    stack install intero QuickCheck  # for a global installation
+    stack build intero QuickCheck # for a local installation
     ```
-### Note
-
-If you failed to install `stack-run`, please refer https://github.com/yamadapc/stack-run/issues/17#issuecomment-427545735
 
 ## Configuration
 

--- a/README.md
+++ b/README.md
@@ -51,7 +51,7 @@
     curl -sSL https://get.haskellstack.org/ | sh
     ```
 
-  * Install [Intero](https://github.com/commercialhaskell/intero) (code completion and type information), [QuickCheck](https://hackage.haskell.org/package/QuickCheck) (test suite) and [stack-run](https://hackage.haskell.org/package/stack-run):
+  * Install [Intero](https://github.com/commercialhaskell/intero) (code completion and type information), and [QuickCheck](https://hackage.haskell.org/package/QuickCheck) (test suite) 
 
     ```shell
     stack install intero QuickCheck  # for a global installation


### PR DESCRIPTION
stack-run is both deprecated and superseded by `stack run` which is in fact the command that is used, as is evident in 
https://github.com/haskelly-dev/Haskelly/blob/597a8e9408701791e05c00819db0f4d0e9cc8caa/src/Basic/commands.ts#L59

`term.sendText(`stack run ${commandsParams.stackRunParams || ""}`);`